### PR TITLE
Use the height of the document element

### DIFF
--- a/mailboxzero/templates/email.html
+++ b/mailboxzero/templates/email.html
@@ -7,10 +7,8 @@
   id="message"
   referrerpolicy="no-referrer"
   sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
-  onload='javascript:(function(o){o.style.height=o.contentWindow.document.body.scrollHeight+"px";}(this));' style="height:400px;width:100%;border:none;overflow:hidden;"
+  onload='javascript:(function(o){o.style.height=o.contentWindow.document.documentElement.scrollHeight+"px";}(this));' style="height:400px;width:100%;border:none;overflow:hidden;"
   srcdoc="{% raw raw_message_html %}">
 </iframe>
 
-<!-- allow="camera 'none'; microphone 'none'; layout-animations 'none'; unoptimized-images 'none'; oversized-images 'none'; sync-script 'none'; sync-xhr 'none'; unsized-media 'none';">
- -->
 {% end %}


### PR DESCRIPTION
This will take into account margins that might have been added to the body tag. Emails sent from GMail seem to have additional margin, which leads to scrolling inside the iframe if we don't make this change.