### PR TITLE
Raise the Finish exception so requests end

### DIFF
--- a/mailboxzero/__init__.py
+++ b/mailboxzero/__init__.py
@@ -78,7 +78,7 @@ class BaseHandler(RequestHandler):
     def force_trailing_slash(self):
         if not self.request.uri.endswith("/"):
             self.redirect(self.request.uri + "/", status=301)
-            return
+            raise web.Finish()
 
 
 class ViewMailBoxHandler(BaseHandler):


### PR DESCRIPTION
After telling the browser to redirect the request should end. Without the exception the handler that called us would continue to run and output HTML.