### PR TITLE
Change the welcome page and add qmq.ch/q shortcut

### DIFF
--- a/mailboxzero/__init__.py
+++ b/mailboxzero/__init__.py
@@ -82,6 +82,15 @@ class WelcomeHandler(RequestHandler):
             self.render("welcome.html", random_email=random_email)
 
 
+class QuickHandler(RequestHandler):
+    def get(self):
+        predicate = random.choice(friendlywords.predicates)
+        object = random.choice(friendlywords.objects)
+        random_email = f"{predicate}-{object}@qmq.ch"
+
+        self.redirect(f"/view/{random_email}/")
+
+
 class BaseHandler(RequestHandler):
     @property
     def base_maildir(self):
@@ -254,6 +263,7 @@ class WebApplication(tornado.web.Application):
     def __init__(self, base_maildir, debug=False):
         handlers = [
             (r"/", WelcomeHandler),
+            (r"/q", QuickHandler),
             (r"/api", PingHandler),
             (r"/api/([^/]+)", MailBoxHandler),
             (r"/api/([^/]+)/([^/]+)", EMailHandler),
@@ -393,7 +403,7 @@ _DEFAULT_DOMAINS = {
 
 def start_all(
     base_maildir="/tmp/mb0",
-    gc_interval=180,
+    gc_interval=180 * 10000,
     debug=False,
     http_port=8880,
     smtp_port=25,

--- a/mailboxzero/__init__.py
+++ b/mailboxzero/__init__.py
@@ -403,7 +403,7 @@ _DEFAULT_DOMAINS = {
 
 def start_all(
     base_maildir="/tmp/mb0",
-    gc_interval=180 * 10000,
+    gc_interval=180,
     debug=False,
     http_port=8880,
     smtp_port=25,

--- a/mailboxzero/templates/mailbox.html
+++ b/mailboxzero/templates/mailbox.html
@@ -14,6 +14,7 @@
 </h1>
 {% if not email_ids%}
 <p>This inbox is empty.</p>
+<p class="text-muted">Click the email address to copy it to your clipboard.</p>
 {% else %}
   {% for email_id in email_ids %}
     {% module Template("_email_link.html", email_id=email_id, summary=summaries[email_id]) %}

--- a/mailboxzero/templates/welcome.html
+++ b/mailboxzero/templates/welcome.html
@@ -22,13 +22,8 @@
       </form>
     </div>
     <p>
-      Can't think of an email to use? Try
-      <span data-controller="clipboard" style="display: inline-block">
-        <span data-clipboard-target="source" data-action="click->clipboard#copy" class="font-monospace user-select-all">{{ random_email }}</span>
-        <button data-action="clipboard#copy" class="btn btn-outline-secondary btn-sm position-relative">
-          Copy <span data-clipboard-target="notification" class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-secondary">Copied</span>
-        </button>
-      </span>
+      Need a random inbox? Visit <a href="/q">qmq.ch/q</a>! Every time you
+      visit qmq.ch/q we will pick a new random email address and show you its inbox.
     </p>
   </div>
 </main>


### PR DESCRIPTION
The goal is to reduce the number of clicks/steps involved in performing the common task of "I need an email address to quickly test something".

This introduces the `/q` route which takes the user directly to a random inbox. That way people who just need an inbox can visit that URL and then copy the email address by clicking on it in the header. This is much simpler than havign to open the homepage, then copy the email, then paste it and click.