### PR TITLE
More vertical padding, fix a tag width

### DIFF
--- a/mailboxzero/templates/base.html
+++ b/mailboxzero/templates/base.html
@@ -13,7 +13,7 @@
     {% block head %}{% end %}
   </head>
   <body class="d-flex flex-column justify-content-between vh-100">
-    <div class="container mt-2 mt-md-5">
+    <div class="container mt-4 mt-md-5">
       {% block body %}{% end %}
     </div>
     {% block bottom %}{% end %}

--- a/mailboxzero/templates/email.html
+++ b/mailboxzero/templates/email.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block body %}
 
-<a href="./" class="link-secondary mb-4 d-block">&larr; Back to Inbox</a>
+<a href="./" class="link-secondary mb-4 d-block" style="width: max-content">&larr; Back to Inbox</a>
 
 <main>
   <h1 class="mb-4" style="hyphens: auto; overflow-wrap: break-word; word-wrap: break-word;">{{ subject }}</h1>

--- a/mailboxzero/templates/mailbox.html
+++ b/mailboxzero/templates/mailbox.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block body %}
 
-<a href="../.." class="link-secondary mb-4 d-block">Different address &olarr;</a>
+<a href="../.." class="link-secondary mb-4 d-block" style="width: max-content">Different address &olarr;</a>
 
 <h1 class="mb-4">Emails for
   <span


### PR DESCRIPTION
On mobile/small screens the "new email address" link was very close to the edge of the screen. This moves it down a bit.

Also fixes a small visual gore: the `<a>` element is set as `display: block` which makes it as wide as the whole column. This is a bit weird. Using `mac-content` fixes that.